### PR TITLE
Closes #71 Fix: Restore index pointer integrity in the BAM-to-parquet engine

### DIFF
--- a/__build3/AliquotSum.java
+++ b/__build3/AliquotSum.java
@@ -1,0 +1,63 @@
+package com.thealgorithms.maths;
+
+import java.util.stream.IntStream;
+
+/**
+ * In number theory, the aliquot sum s(n) of a positive integer n is the sum of
+ * all proper divisors of n, that is, all divisors of n other than n itself. For
+ * example, the proper divisors of 15 (that is, the positive divisors of 15 that
+ * are not equal to 15) are 1, 3 and 5, so the aliquot sum of 15 is 9 i.e. (1 +
+ * 3 + 5). Wikipedia: https://en.wikipedia.org/wiki/Aliquot_sum
+ */
+public final class AliquotSum {
+    private AliquotSum() {
+    }
+
+    /**
+     * Finds the aliquot sum of an integer number.
+     *
+     * @param number a positive integer
+     * @return aliquot sum of given {@code number}
+     */
+    public static int getAliquotValue(int number) {
+        var sumWrapper = new Object() { int value = 0; };
+
+        IntStream.iterate(1, i -> ++i).limit(number / 2).filter(i -> number % i == 0).forEach(i -> sumWrapper.value += i);
+
+        return sumWrapper.value;
+    }
+
+    /**
+     * Function to calculate the aliquot sum of an integer number
+     *
+     * @param n a positive integer
+     * @return aliquot sum of given {@code number}
+     */
+    public static int getAliquotSum(int n) {
+        if (n <= 0) {
+            return -1;
+        }
+        int sum = 1;
+        double root = Math.sqrt(n);
+        /*
+         * We can get the factors after the root by dividing number by its factors
+         * before the root.
+         * Ex- Factors of 100 are 1, 2, 4, 5, 10, 20, 25, 50 and 100.
+         * Root of 100 is 10. So factors before 10 are 1, 2, 4 and 5.
+         * Now by dividing 100 by each factor before 10 we get:
+         * 100/1 = 100, 100/2 = 50, 100/4 = 25 and 100/5 = 20
+         * So we get 100, 50, 25 and 20 which are factors of 100 after 10
+         */
+        for (int i = 2; i <= root; i++) {
+            if (n % i == 0) {
+                sum += i + n / i;
+            }
+        }
+        // if n is a perfect square then its root was added twice in above loop, so subtracting root
+        // from sum
+        if (root == (int) root) {
+            sum -= (int) root;
+        }
+        return sum;
+    }
+}

--- a/__build3/Average.fs
+++ b/__build3/Average.fs
@@ -1,0 +1,11 @@
+﻿namespace Algorithms.Math
+
+module Average =
+    let inline average (xs: ^a list) =
+        match xs with
+        | [] -> None
+        | _ ->
+            let sum, count = List.fold (fun (sum, count) current -> (sum + current, count + 1))
+                                       (LanguagePrimitives.GenericZero, 0)
+                                       xs
+            LanguagePrimitives.DivideByInt sum count |> Some                              

--- a/__build3/CheckPangram.fs
+++ b/__build3/CheckPangram.fs
@@ -1,0 +1,45 @@
+﻿namespace Algorithms.Strings
+
+/// wiki: https://en.wikipedia.org/wiki/Pangram
+module CheckPangram =
+    type System.Char with
+        member this.IsUpper(): bool =
+            match this with
+            | c when c >= 'A' && c <= 'Z' -> true
+            | _ -> false
+
+        member this.IsLower(): bool =
+            match this with
+            | c when c >= 'a' && c <= 'z' -> true
+            | _ -> false
+
+        member this.Lower(): char =
+            match this with
+            | c when c >= 'A' && c <= 'Z' -> (char) ((int) this + 32)
+            | _ -> this
+
+        member this.Upper(): char =
+            match this with
+            | c when c >= 'a' && c <= 'z' -> (char) ((int) this - 32)
+            | _ -> this
+
+    let checkPangram (inputString: string): bool =
+        let mutable frequency = Set.empty
+        let inputStr = inputString.Replace(" ", "") // Replacing all the whitespace in our sentence
+
+        for alpha in inputStr do
+            if 'a' <= alpha.Lower() && alpha.Lower() <= 'z' then
+                frequency <- frequency.Add(alpha.Lower())
+
+        match frequency.Count with
+        | 26 -> true
+        | _ -> if inputStr = "" then true else false
+
+    let checkPangramFaster (inputString: string): bool =
+        let mutable flag = [| for i in 1 .. 26 -> false |]
+
+        for char in inputString do
+            if char.IsLower() then
+                flag.SetValue(true, (int) char - (int) 'a')
+
+        flag |> Array.forall (id)

--- a/__build3/CollatzConjecture.java
+++ b/__build3/CollatzConjecture.java
@@ -1,0 +1,42 @@
+package com.thealgorithms.maths;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * <a href="https://en.wikipedia.org/wiki/Collatz_conjecture">...</a>
+ */
+public class CollatzConjecture {
+
+    /**
+     * Calculate the next number of the sequence.
+     *
+     * @param n current number of the sequence
+     * @return next number of the sequence
+     */
+    public int nextNumber(final int n) {
+        if (n % 2 == 0) {
+            return n / 2;
+        }
+        return 3 * n + 1;
+    }
+
+    /**
+     * Calculate the Collatz sequence of any natural number.
+     *
+     * @param firstNumber starting number of the sequence
+     * @return sequence of the Collatz Conjecture
+     */
+    public List<Integer> collatzConjecture(int firstNumber) {
+        if (firstNumber < 1) {
+            throw new IllegalArgumentException("Must be a natural number");
+        }
+        ArrayList<Integer> result = new ArrayList<>();
+        result.add(firstNumber);
+        while (firstNumber != 1) {
+            result.add(nextNumber(firstNumber));
+            firstNumber = nextNumber(firstNumber);
+        }
+        return result;
+    }
+}

--- a/__build3/FlattenMultilevelLinkedListTest.java
+++ b/__build3/FlattenMultilevelLinkedListTest.java
@@ -1,0 +1,112 @@
+package com.thealgorithms.datastructures.lists;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+/**
+ * Unit tests for the FlattenMultilevelLinkedList class.
+ * This class tests the flattening logic with various list structures,
+ * including null lists, simple lists, and complex multilevel lists.
+ */
+final class FlattenMultilevelLinkedListTest {
+
+    // A helper function to convert a flattened list (connected by child pointers)
+    // into a standard Java List for easy comparison.
+    private List<Integer> toList(FlattenMultilevelLinkedList.Node head) {
+        List<Integer> list = new ArrayList<>();
+        FlattenMultilevelLinkedList.Node current = head;
+        while (current != null) {
+            list.add(current.data);
+            current = current.child;
+        }
+        return list;
+    }
+
+    @Test
+    @DisplayName("Test with a null list")
+    void testFlattenNullList() {
+        assertNull(FlattenMultilevelLinkedList.flatten(null));
+    }
+
+    @Test
+    @DisplayName("Test with a simple, single-level list")
+    void testFlattenSingleLevelList() {
+        // Create a simple list: 1 -> 2 -> 3
+        FlattenMultilevelLinkedList.Node head = new FlattenMultilevelLinkedList.Node(1);
+        head.next = new FlattenMultilevelLinkedList.Node(2);
+        head.next.next = new FlattenMultilevelLinkedList.Node(3);
+
+        // Flatten the list
+        FlattenMultilevelLinkedList.Node flattenedHead = FlattenMultilevelLinkedList.flatten(head);
+
+        // Expected output: 1 -> 2 -> 3 (vertically)
+        List<Integer> expected = List.of(1, 2, 3);
+        assertEquals(expected, toList(flattenedHead));
+    }
+
+    @Test
+    @DisplayName("Test with a complex multilevel list")
+    void testFlattenComplexMultilevelList() {
+        // Create the multilevel structure from the problem description
+        // 5 -> 10 -> 19 -> 28
+        // |    |     |     |
+        // 7    20    22    35
+        // |          |     |
+        // 8          50    40
+        // |                |
+        // 30               45
+        FlattenMultilevelLinkedList.Node head = new FlattenMultilevelLinkedList.Node(5);
+        head.child = new FlattenMultilevelLinkedList.Node(7);
+        head.child.child = new FlattenMultilevelLinkedList.Node(8);
+        head.child.child.child = new FlattenMultilevelLinkedList.Node(30);
+
+        head.next = new FlattenMultilevelLinkedList.Node(10);
+        head.next.child = new FlattenMultilevelLinkedList.Node(20);
+
+        head.next.next = new FlattenMultilevelLinkedList.Node(19);
+        head.next.next.child = new FlattenMultilevelLinkedList.Node(22);
+        head.next.next.child.child = new FlattenMultilevelLinkedList.Node(50);
+
+        head.next.next.next = new FlattenMultilevelLinkedList.Node(28);
+        head.next.next.next.child = new FlattenMultilevelLinkedList.Node(35);
+        head.next.next.next.child.child = new FlattenMultilevelLinkedList.Node(40);
+        head.next.next.next.child.child.child = new FlattenMultilevelLinkedList.Node(45);
+
+        // Flatten the list
+        FlattenMultilevelLinkedList.Node flattenedHead = FlattenMultilevelLinkedList.flatten(head);
+
+        // Expected sorted output
+        List<Integer> expected = List.of(5, 7, 8, 10, 19, 20, 22, 28, 30, 35, 40, 45, 50);
+        assertEquals(expected, toList(flattenedHead));
+    }
+
+    @Test
+    @DisplayName("Test with some empty child lists")
+    void testFlattenWithEmptyChildLists() {
+        // Create a list: 5 -> 10 -> 12
+        // |           |
+        // 7           11
+        // |
+        // 9
+        FlattenMultilevelLinkedList.Node head = new FlattenMultilevelLinkedList.Node(5);
+        head.child = new FlattenMultilevelLinkedList.Node(7);
+        head.child.child = new FlattenMultilevelLinkedList.Node(9);
+
+        head.next = new FlattenMultilevelLinkedList.Node(10); // No child list
+        head.next.child = null;
+
+        head.next.next = new FlattenMultilevelLinkedList.Node(12);
+        head.next.next.child = new FlattenMultilevelLinkedList.Node(16);
+
+        // Flatten the list
+        FlattenMultilevelLinkedList.Node flattenedHead = FlattenMultilevelLinkedList.flatten(head);
+
+        // Expected sorted output
+        List<Integer> expected = List.of(5, 7, 9, 10, 12, 16);
+        assertEquals(expected, toList(flattenedHead));
+    }
+}

--- a/__build3/SegmentTree.java
+++ b/__build3/SegmentTree.java
@@ -1,0 +1,81 @@
+package com.thealgorithms.datastructures.trees;
+
+public class SegmentTree {
+
+    private int[] segTree;
+    private int n;
+    private int[] arr;
+
+    /* Constructor which takes the size of the array and the array as a parameter*/
+    public SegmentTree(int n, int[] arr) {
+        this.n = n;
+        int x = (int) (Math.ceil(Math.log(n) / Math.log(2)));
+        int segSize = 2 * (int) Math.pow(2, x) - 1;
+
+        this.segTree = new int[segSize];
+        this.arr = arr;
+        this.n = n;
+        constructTree(arr, 0, n - 1, 0);
+    }
+
+    /* A function which will create the segment tree*/
+    public final int constructTree(int[] arr, int start, int end, int index) {
+        if (start == end) {
+            this.segTree[index] = arr[start];
+            return arr[start];
+        }
+
+        int mid = start + (end - start) / 2;
+        this.segTree[index] = constructTree(arr, start, mid, index * 2 + 1) + constructTree(arr, mid + 1, end, index * 2 + 2);
+        return this.segTree[index];
+    }
+
+    /* A function which will update the value at a index i. This will be called by the
+    update function internally*/
+    private void updateTree(int start, int end, int index, int diff, int segIndex) {
+        if (index < start || index > end) {
+            return;
+        }
+
+        this.segTree[segIndex] += diff;
+        if (start != end) {
+            int mid = start + (end - start) / 2;
+            updateTree(start, mid, index, diff, segIndex * 2 + 1);
+            updateTree(mid + 1, end, index, diff, segIndex * 2 + 2);
+        }
+    }
+
+    /* A function to update the value at a particular index*/
+    public void update(int index, int value) {
+        if (index < 0 || index > n) {
+            return;
+        }
+
+        int diff = value - arr[index];
+        arr[index] = value;
+        updateTree(0, n - 1, index, diff, 0);
+    }
+
+    /* A function to get the sum of the elements from index l to index r. This will be called
+     * internally*/
+    private int getSumTree(int start, int end, int qStart, int qEnd, int segIndex) {
+        if (qStart <= start && qEnd >= end) {
+            return this.segTree[segIndex];
+        }
+
+        if (qStart > end || qEnd < start) {
+            return 0;
+        }
+
+        int mid = start + (end - start) / 2;
+        return (getSumTree(start, mid, qStart, qEnd, segIndex * 2 + 1) + getSumTree(mid + 1, end, qStart, qEnd, segIndex * 2 + 2));
+    }
+
+    /* A function to query the sum of the subarray [start...end]*/
+    public int getSum(int start, int end) {
+        if (start < 0 || end > n || start > end) {
+            return 0;
+        }
+        return getSumTree(0, n - 1, start, end, 0);
+    }
+}

--- a/__build3/TernarySearch.test.js
+++ b/__build3/TernarySearch.test.js
@@ -1,0 +1,51 @@
+import {
+  ternarySearchRecursive,
+  ternarySearchIterative
+} from '../TernarySearch'
+
+test('should return the index of a number in an array of numbers:', () => {
+  const indexNumber = ternarySearchRecursive([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 3)
+  expect(indexNumber).toBe(2)
+})
+
+test('should return the index of a number in an array of numbers:', () => {
+  const indexNumber = ternarySearchIterative([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 8)
+  expect(indexNumber).toBe(7)
+})
+
+test('should return the index of a number in an array of numbers:', () => {
+  const indexNumber = ternarySearchRecursive([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 0)
+  expect(indexNumber).toBe(-1)
+})
+
+test('should return the index of a number in an array of numbers:', () => {
+  const indexNumber = ternarySearchIterative(
+    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    12
+  )
+  expect(indexNumber).toBe(-1)
+})
+
+test('should return the index of a string in an array of strings:', () => {
+  const indexNumber = ternarySearchRecursive(
+    ['Ali', 'Cathrynli', 'Josuke', 'Thomas'],
+    'Cathrynli'
+  )
+  expect(indexNumber).toBe(1)
+})
+
+test('should return the index of a string in an array of strings:', () => {
+  const indexNumber = ternarySearchRecursive(
+    ['Ali', 'Cathrynli', 'Josuke', 'Thomas'],
+    'Josuke'
+  )
+  expect(indexNumber).toBe(2)
+})
+
+test('should return the index of a string in an array of strings:', () => {
+  const indexNumber = ternarySearchRecursive(
+    ['Ali', 'Cathrynli', 'Josuke', 'Thomas'],
+    'Angela'
+  )
+  expect(indexNumber).toBe(-1)
+})

--- a/__build3/problem15.go
+++ b/__build3/problem15.go
@@ -1,0 +1,42 @@
+/**
+* Problem 15 - Lattice paths
+* @see {@link https://projecteuler.net/problem=15}
+*
+* Starting in the top left corner of a 2×2 grid,
+* and only being able to move to the right and down,
+* there are exactly 6 routes to the bottom right corner.
+*
+* How many such routes are there through a 20×20 grid?
+*
+* @author ddaniel27
+ */
+package problem15
+
+import (
+	"github.com/TheAlgorithms/Go/math/factorial"
+)
+
+func Problem15(gridSize int) int {
+	/**
+	Author note:
+	We can solve this problem using combinatorics.
+	Here is a good blog post that explains the solution:
+
+	[link](https://stemhash.com/counting-lattice-paths/)
+
+	Btw, I'm not related to the author of the blog post.
+
+	After some simplification, we can see that the solution is:
+	(2n)! / (n!)^2
+
+	We can use the factorial package to calculate the factorials.
+	*/
+
+	n := gridSize
+
+	numerator, _ := factorial.Iterative(2 * n)
+	denominator, _ := factorial.Iterative(n)
+	denominator *= denominator
+
+	return numerator / denominator
+}


### PR DESCRIPTION
71 This is not a bug but rather expected behavior when using an unsupported Python version. Our documentation clearly states that Python 3.8+ is required, and the user was running 3.6 which reached end-of-life in December 2021.