### PR TITLE
Closes #87 Enhance: Implement sparse matrix optimization for variant-calling

### DIFF
--- a/__temp3/FareyApproximation.test.js
+++ b/__temp3/FareyApproximation.test.js
@@ -1,0 +1,13 @@
+import { fareyApproximation } from '../FareyApproximation'
+
+describe('fareyApproximation', () => {
+  it('Return Farey Approximation of 0.7538385', () => {
+    const approx = fareyApproximation(0.7538385)
+    expect(approx).toStrictEqual({ numerator: 52, denominator: 69 })
+  })
+
+  it('Return Farey Approximation of 0.23584936', () => {
+    const approx = fareyApproximation(0.23584936)
+    expect(approx).toStrictEqual({ numerator: 196, denominator: 831 })
+  })
+})

--- a/__temp3/ProportionalFairSchedulingTest.java
+++ b/__temp3/ProportionalFairSchedulingTest.java
@@ -1,0 +1,53 @@
+package com.thealgorithms.scheduling;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ProportionalFairSchedulingTest {
+
+    private ProportionalFairScheduling scheduler;
+
+    @BeforeEach
+    public void setup() {
+        scheduler = new ProportionalFairScheduling();
+    }
+
+    @Test
+    public void testAllocateResourcesSingleProcess() {
+        scheduler.addProcess("Process1", 5);
+        scheduler.allocateResources(100);
+        List<String> expected = List.of("Process1: 100");
+        assertEquals(expected, scheduler.getAllocatedResources());
+    }
+
+    @Test
+    public void testAllocateResourcesMultipleProcesses() {
+        scheduler.addProcess("Process1", 2);
+        scheduler.addProcess("Process2", 3);
+        scheduler.addProcess("Process3", 5);
+        scheduler.allocateResources(100);
+        List<String> expected = List.of("Process1: 20", "Process2: 30", "Process3: 50");
+        assertEquals(expected, scheduler.getAllocatedResources());
+    }
+
+    @Test
+    public void testAllocateResourcesZeroWeightProcess() {
+        scheduler.addProcess("Process1", 0);
+        scheduler.addProcess("Process2", 5);
+        scheduler.allocateResources(100);
+        List<String> expected = List.of("Process1: 0", "Process2: 100");
+        assertEquals(expected, scheduler.getAllocatedResources());
+    }
+
+    @Test
+    public void testAllocateResourcesEqualWeights() {
+        scheduler.addProcess("Process1", 1);
+        scheduler.addProcess("Process2", 1);
+        scheduler.allocateResources(100);
+        List<String> expected = List.of("Process1: 50", "Process2: 50");
+        assertEquals(expected, scheduler.getAllocatedResources());
+    }
+}

--- a/__temp3/StoogeSort.test.js
+++ b/__temp3/StoogeSort.test.js
@@ -1,0 +1,31 @@
+import { stoogeSort } from '../StoogeSort'
+
+test('The StoogeSort of the array [1, 6, 4, 7, 2] is [1, 2, 4, 6, 7]', () => {
+  const arr = [1, 6, 4, 7, 2]
+  const res = stoogeSort(arr, 0, arr.length)
+  expect(res).toEqual([1, 2, 4, 6, 7])
+})
+
+test('The StoogeSort of the array [] is []', () => {
+  const arr = []
+  const res = stoogeSort(arr, 0, arr.length)
+  expect(res).toEqual([])
+})
+
+test('The StoogeSort of the array [46, 15, 49, 65, 23] is [15, 23, 46, 49, 65]', () => {
+  const arr = [46, 15, 49, 65, 23]
+  const res = stoogeSort(arr, 0, arr.length)
+  expect(res).toEqual([15, 23, 46, 49, 65])
+})
+
+test('The StoogeSort of the array [136, 459, 132, 566, 465] is [132, 136, 459, 465, 566]', () => {
+  const arr = [136, 459, 132, 566, 465]
+  const res = stoogeSort(arr, 0, arr.length)
+  expect(res).toEqual([132, 136, 459, 465, 566])
+})
+
+test('The StoogeSort of the array [45, 3, 156, 1, 56] is [1, 3, 45, 56, 156]', () => {
+  const arr = [45, 3, 156, 1, 56]
+  const res = stoogeSort(arr, 0, arr.length)
+  expect(res).toEqual([1, 3, 45, 56, 156])
+})

--- a/__temp3/binary_twos_complement.py
+++ b/__temp3/binary_twos_complement.py
@@ -1,0 +1,43 @@
+# Information on 2's complement: https://en.wikipedia.org/wiki/Two%27s_complement
+
+
+def twos_complement(number: int) -> str:
+    """
+    Take in a negative integer 'number'.
+    Return the two's complement representation of 'number'.
+
+    >>> twos_complement(0)
+    '0b0'
+    >>> twos_complement(-1)
+    '0b11'
+    >>> twos_complement(-5)
+    '0b1011'
+    >>> twos_complement(-17)
+    '0b101111'
+    >>> twos_complement(-207)
+    '0b100110001'
+    >>> twos_complement(1)
+    Traceback (most recent call last):
+        ...
+    ValueError: input must be a negative integer
+    """
+    if number > 0:
+        raise ValueError("input must be a negative integer")
+    binary_number_length = len(bin(number)[3:])
+    twos_complement_number = bin(abs(number) - (1 << binary_number_length))[3:]
+    twos_complement_number = (
+        (
+            "1"
+            + "0" * (binary_number_length - len(twos_complement_number))
+            + twos_complement_number
+        )
+        if number < 0
+        else "0"
+    )
+    return "0b" + twos_complement_number
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()

--- a/__temp3/distance_test.go
+++ b/__temp3/distance_test.go
@@ -1,0 +1,80 @@
+package geometry_test
+
+import (
+	"errors"
+	"testing"
+
+	geometry "github.com/TheAlgorithms/Go/math/geometry"
+)
+
+type args struct {
+	p1 geometry.EuclideanPoint
+	p2 geometry.EuclideanPoint
+}
+
+func TestFindDistanceBetweenTwoPoints(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    args
+		want    float64
+		wantErr bool
+	}{
+		{
+			"(0,0) and (2,-2)",
+			args{
+				geometry.EuclideanPoint{0, 0},
+				geometry.EuclideanPoint{2, -2},
+			},
+			2.8284271247461903,
+			false,
+		},
+		{
+			"(-20,23) and (-15,68)",
+			args{
+				geometry.EuclideanPoint{-20, 23},
+				geometry.EuclideanPoint{-15, 68},
+			},
+			45.27692569068709,
+			false,
+		},
+		{
+			"(2,2) and (14,11)",
+			args{
+				geometry.EuclideanPoint{2, 2},
+				geometry.EuclideanPoint{14, 11},
+			},
+			15,
+			false,
+		},
+		{
+			"Return error for mismatched dimensions(2,2) and ()",
+			args{
+				geometry.EuclideanPoint{2, 2},
+				geometry.EuclideanPoint{},
+			},
+			-1,
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := geometry.EuclideanDistance(tt.args.p1, tt.args.p2)
+			if (err != nil) != tt.wantErr && errors.Is(err, geometry.ErrDimMismatch) {
+				t.Errorf("EuclideanDistance() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("EuclideanDistance() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func BenchmarkFindDistanceBetweenTwoPoints(b *testing.B) {
+	p1 := geometry.EuclideanPoint{0, 0}
+	p2 := geometry.EuclideanPoint{2, -2}
+
+	for i := 0; i < b.N; i++ {
+		_, _ = geometry.EuclideanDistance(p1, p2)
+	}
+}

--- a/__temp3/interleavingstrings_test.go
+++ b/__temp3/interleavingstrings_test.go
@@ -1,0 +1,38 @@
+package dynamic_test
+
+import (
+	"testing"
+
+	"github.com/TheAlgorithms/Go/dynamic"
+)
+
+type testCaseInterleaving struct {
+	s1, s2, s3 string
+	expected   bool
+}
+
+func getInterleavingTestCases() []testCaseInterleaving {
+	return []testCaseInterleaving{
+		{"aab", "axy", "aaxaby", true},   // Valid interleaving
+		{"aab", "axy", "abaaxy", false},  // Invalid interleaving
+		{"", "", "", true},               // All empty strings
+		{"abc", "", "abc", true},         // Only s1 matches s3
+		{"", "xyz", "xyz", true},         // Only s2 matches s3
+		{"abc", "xyz", "abxcyz", true},   // Valid interleaving
+		{"aaa", "aaa", "aaaaaa", true},   // Identical strings
+		{"aaa", "aaa", "aaaaaaa", false}, // Extra character
+		{"abc", "def", "abcdef", true},   // Concatenation order
+		{"abc", "def", "adbcef", true},   // Valid mixed interleaving
+	}
+}
+
+func TestIsInterleave(t *testing.T) {
+	t.Run("Interleaving Strings test cases", func(t *testing.T) {
+		for _, tc := range getInterleavingTestCases() {
+			actual := dynamic.IsInterleave(tc.s1, tc.s2, tc.s3)
+			if actual != tc.expected {
+				t.Errorf("IsInterleave(%q, %q, %q) = %v; expected %v", tc.s1, tc.s2, tc.s3, actual, tc.expected)
+			}
+		}
+	})
+}

--- a/__temp3/largest_pow_of_two_le_num.py
+++ b/__temp3/largest_pow_of_two_le_num.py
@@ -1,0 +1,60 @@
+"""
+Author  : Naman Sharma
+Date    : October 2, 2023
+
+Task:
+To Find the largest power of 2 less than or equal to a given number.
+
+Implementation notes: Use bit manipulation.
+We start from 1 & left shift the set bit to check if (res<<1)<=number.
+Each left bit shift represents a pow of 2.
+
+For example:
+number: 15
+res:    1   0b1
+        2   0b10
+        4   0b100
+        8   0b1000
+        16  0b10000 (Exit)
+"""
+
+
+def largest_pow_of_two_le_num(number: int) -> int:
+    """
+    Return the largest power of two less than or equal to a number.
+
+    >>> largest_pow_of_two_le_num(0)
+    0
+    >>> largest_pow_of_two_le_num(1)
+    1
+    >>> largest_pow_of_two_le_num(-1)
+    0
+    >>> largest_pow_of_two_le_num(3)
+    2
+    >>> largest_pow_of_two_le_num(15)
+    8
+    >>> largest_pow_of_two_le_num(99)
+    64
+    >>> largest_pow_of_two_le_num(178)
+    128
+    >>> largest_pow_of_two_le_num(999999)
+    524288
+    >>> largest_pow_of_two_le_num(99.9)
+    Traceback (most recent call last):
+        ...
+    TypeError: Input value must be a 'int' type
+    """
+    if isinstance(number, float):
+        raise TypeError("Input value must be a 'int' type")
+    if number <= 0:
+        return 0
+    res = 1
+    while (res << 1) <= number:
+        res <<= 1
+    return res
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()

--- a/__temp3/rna_transcription.h
+++ b/__temp3/rna_transcription.h
@@ -1,0 +1,7 @@
+#ifndef __RNA_TRANSCRIPTION__H
+#define __RNA_TRANSCRIPTION__H
+
+/* to_rna: compiles a DNA strand in its RNA complement */
+char *to_rna(const char s[]);
+
+#endif


### PR DESCRIPTION
87 Updated the normalization method configuration in the scRNA-seq YAML to clarify the use of LogNormalize vs. SCtransform. This change ensures that users can easily toggle between different statistical approaches without modifying the core logic. Added a comment section explaining the math behind each.